### PR TITLE
Support SQLcl

### DIFF
--- a/src/main/java/com/onevizion/scmdb/SqlScriptExecutor.java
+++ b/src/main/java/com/onevizion/scmdb/SqlScriptExecutor.java
@@ -12,7 +12,7 @@ import java.net.URL;
 import static com.onevizion.scmdb.ColorLogger.Color.YELLOW;
 
 public class SqlScriptExecutor {
-    private static final String SQL_PLUS_COMMAND = "sqlplus";
+    private static final String SQL_PLUS_COMMAND = "sql";
     private static final String INVALID_OBJECT_POSTFIX = "is invalid.";
 
     private Executor executor;
@@ -60,6 +60,7 @@ public class SqlScriptExecutor {
         executor.setWorkingDirectory(workingDir);
         try {
             return executor.execute(commandLine);
+
         } catch (ExecuteException e) {
             return e.getExitValue();
         } catch (IOException e) {


### PR DESCRIPTION
Hi team,

Now scmdb supports Oracle SQLcl for scripts execution instead of SQL*Plus.
Furthermore, I have quickly checked out the decompiled code of SQLcl and have found out that this tool has been written as a command line tool and it does not have special API or development kit as well as JavaDoc.
However, there are some SQLcl contains some JAR files we can use for script execution (MIT license). For example: [https://github.com/oracle/oracle-db-tools/blob/master/sqlcl/examples/jython_example.sh](url)