### PR TITLE
Depl-214834 Table related objects should be sorted during generation of ddl

### DIFF
--- a/src/main/java/com/onevizion/scmdb/DdlGenerator.java
+++ b/src/main/java/com/onevizion/scmdb/DdlGenerator.java
@@ -206,7 +206,6 @@ public class DdlGenerator {
             ddl = ddl.replaceAll("\\s+;$", ";");
             indexesDdl.append(ddl);
         }
-        indexesDdl.append("\r\n");
         return indexesDdl.toString();
     }
 


### PR DESCRIPTION
Depl-214834-92803 [CR] Table constraints and indexes should be sorted during generation of ddl