### PR TITLE
DB-219869 Add ddl generation support for oracle types

### DIFF
--- a/src/main/java/com/onevizion/scmdb/dao/DdlDao.java
+++ b/src/main/java/com/onevizion/scmdb/dao/DdlDao.java
@@ -24,7 +24,9 @@ public class DdlDao extends AbstractDaoOra {
             "   or object_type = 'PACKAGE'\n" +
             "   or object_type = 'PACKAGE BODY'\n" +
             "   or object_type = 'TRIGGER'\n" +
-            "   or object_type = 'TYPE'\n" +
+            "   or (object_type = 'TYPE'\n" +
+            "     and generated = 'N'\n" +
+            "     and object_name not like 'T$%')\n" +
             "   or object_type = 'TYPE BODY'\n";
 
     private final static RowMapper<DbObject> rowMapper = (rs, rowNum) -> {

--- a/src/main/java/com/onevizion/scmdb/vo/DbObjectType.java
+++ b/src/main/java/com/onevizion/scmdb/vo/DbObjectType.java
@@ -15,7 +15,7 @@ public enum DbObjectType {
     SEQUENCE("sequence", asList("create sequence", "drop sequence")),
     TRIGGER("trigger", asList("create trigger", "replace trigger", "drop trigger", "alter trigger")),
     TYPE_BODY("type body", asList("create type body", "replace type body", "drop type body")),
-    TYPE_SPEC("type", asList("create type", "alter type", "replace type", "drop type", "type "));
+    TYPE_SPEC("type", asList("create type", "alter type", "replace type", "drop type"));
 
     private String name;
     private List<String> changeKeywords;


### PR DESCRIPTION
DB-219869-109491 [CR] Add ddl generation support for oracle types
Made ignored types started with T$ and deleted word 'type ' from DbObjectType keywords