### PR TITLE
Depl-219606 Optimize scmdb scripts directory scanning performance

### DIFF
--- a/src/main/java/com/onevizion/scmdb/DbManager.java
+++ b/src/main/java/com/onevizion/scmdb/DbManager.java
@@ -58,7 +58,6 @@ public class DbManager {
             logger.info(FIRST_RUN_MESSAGE);
         } else {
             scriptsFacade.cleanExecDir();
-            scriptsFacade.getDbScripts();
             checkUpdatedScripts();
             checkDeletedScripts();
             executeNewScripts();
@@ -192,7 +191,6 @@ public class DbManager {
 
         scriptsFacade.checkDbConnection();
 
-        scriptsFacade.getDbScripts();
         List<SqlScript> scripts = scriptsFacade.getNewScripts();
         scripts.addAll(scriptsFacade.getUpdatedScripts());
         List<SqlScript> scriptsToGenDdl = scripts.stream()

--- a/src/main/resources/beans.xml
+++ b/src/main/resources/beans.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:cache="http://www.springframework.org/schema/cache"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-4.2.xsd">
+        http://www.springframework.org/schema/context/spring-context-4.2.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd">
     <context:property-placeholder ignore-unresolvable="true"/>
+    <cache:annotation-driven />
 
     <bean id="dataSource" class="oracle.ucp.jdbc.PoolDataSourceImpl">
         <property name="connectionFactoryClassName" value="oracle.jdbc.pool.OracleDataSource"/>
@@ -39,6 +43,15 @@
     <bean id="namedParamJdbcTemplate"
           class="org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate">
         <constructor-arg ref="dataSource"/>
+    </bean>
+
+    <bean id="cacheManager"
+          class="org.springframework.cache.support.SimpleCacheManager">
+        <property name="caches">
+            <set>
+                <bean class="org.springframework.cache.concurrent.ConcurrentMapCacheFactoryBean" name="dbScripts"/>
+            </set>
+        </property>
     </bean>
 
     <bean class="com.onevizion.scmdb.AppArguments"/>


### PR DESCRIPTION
Depl-219606-109162 [CR] Optimize scmdb scripts directory scanning performance

Added `@Cacheable` annotation to method `sqlScriptDaoOra.readMap()` and renamed it to `sqlScriptDaoOra.loadDbScriptsMapCached()`. Got rid of the script texts when the method `sqlScriptDaoOra.loadDbScriptsMapCached()` is called. Added script texts reading from DB in the method `DbScriptFacade.copyRollbackToExecDir()` so SCMDB gets texts only if necessary.